### PR TITLE
hotfix: resolving typo in twitter post analytics that was fetching incorrect number of pages

### DIFF
--- a/source_sprout_social/source.py
+++ b/source_sprout_social/source.py
@@ -965,7 +965,7 @@ class TwitterPostAnalytics(SproutSocialStream):
      """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.total_pages = self._get_total_pages(platform_name="twitter", endpoint=f"{self._get_customer_id()}/analytics/profiles")
+        self.total_pages = self._get_total_pages(platform_name="twitter", endpoint=f"{self._get_customer_id()}/analytics/posts")
         
     
     def request_body_json(


### PR DESCRIPTION
This change is applied to tag 0.0.17